### PR TITLE
refactor: 빌드후 spring.kafka.bootstrap-servers 덮어쓰도록 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean build
 
+      - name: Prepare application.yml
+        run: |
+          sed -i 's|bootstrap-servers:.*|bootstrap-servers: '"${{ secrets.KAFKA_BOOTSTRAP_SERVERS }}"'|' src/main/resources/application.yml
+
       - name: login Docker
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
- 빌드 후 github secret값으로 spring.kafka.bootstrap-servers를 덮어쓰도록 수정했습니다.
- 빌드 전에는 배포된 EC2인스턴스의 주소로 접속됩니다.