### PR TITLE
Refactor/#68 알림 조회 시, alarmTime을 포함한 alarmCount 도큐먼트 저장

### DIFF
--- a/src/main/java/com/sparos4th2/alarm/application/AlarmServiceImpl.java
+++ b/src/main/java/com/sparos4th2/alarm/application/AlarmServiceImpl.java
@@ -49,6 +49,7 @@ public class AlarmServiceImpl implements AlarmService {
 		AlarmCount alarmCount = AlarmCount.builder()
 				.receiverUuid(receiverUuid)
 				.alarmCount(0)
+				.alarmTime(LocalDateTime.now())
 				.build();
 
 		alarmCountRepository.save(alarmCount);


### PR DESCRIPTION
알림을 조회할 때, 미확인 알림이 0개가 되야 하는데 예전 데이터 그대로 오는 문제가 있습니다.
이는 알림 조회 시,`alarm_count` 저장하는 도큐먼트에 `alarmTime`이 빠졌기 때문입니다.
미확인 알림 개수 조회할 때, `alarmTime`을 통해 최신 `alarm_count` 부터 조회하고 있기 때문에 알림 조회 시 `alarmTime`을 포함해서 도큐먼트 저장을 하도록 수정했습니다.